### PR TITLE
refactor: Replace token  handling with Location-based methods

### DIFF
--- a/src/api/app/auth.rs
+++ b/src/api/app/auth.rs
@@ -1,3 +1,5 @@
+use crate::api::Location;
+
 impl super::AppApi {
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
@@ -10,8 +12,7 @@ impl super::AppApi {
             .await?;
 
         self.cred.update(|c| {
-            // 刷新 SSO 时效
-            c.sso.refresh(5400);
+            c.refresh(Location::Sso);
         });
 
         Ok(())

--- a/src/api/boya/auth.rs
+++ b/src/api/boya/auth.rs
@@ -25,10 +25,7 @@ impl super::BoyaApi {
             .ok_or_else(|| Error::server("[Boya] Login failed. No token"))?;
 
         self.cred.update(|c| {
-            // 经验证 15 分钟内过期, 我们这里用 10 分钟
-            c.boya_token.set(token.to_string(), 600);
-            // 刷新 SSO 时效
-            c.sso.refresh(5400);
+            c.set(Location::Boya, token.to_string());
         });
         Ok(())
     }

--- a/src/api/boya/universal.rs
+++ b/src/api/boya/universal.rs
@@ -108,7 +108,7 @@ impl super::BoyaApi {
 
         // 刷新 Token 时效
         self.cred.update(|c| {
-            c.boya_token.refresh(600);
+            c.refresh(Location::Boya);
         });
 
         Ok(res)

--- a/src/api/class/auth.rs
+++ b/src/api/class/auth.rs
@@ -52,10 +52,7 @@ impl super::ClassApi {
         match serde_json::from_str::<_ClassLogin>(&res) {
             Ok(res) => {
                 self.cred.update(|c| {
-                    // 至少 7 天, 但即使更多对我们也用处不大了, 也许以后有时间我会测一测极限时间
-                    c.class_token.set(res.result.id, 604800);
-                    // 刷新 SSO 时效
-                    c.sso.refresh(5400);
+                    c.set(Location::Class, res.result.id);
                 });
                 Ok(())
             }

--- a/src/api/cloud/auth.rs
+++ b/src/api/cloud/auth.rs
@@ -57,9 +57,7 @@ impl super::CloudApi {
                 };
             self.cred.update(|c| {
                 // TODO: 我们先默认十分钟过期, 待测试
-                c.cloud_token.set(token, 600);
-                // 刷新 SSO 时效
-                c.sso.refresh(5400);
+                c.set(Location::Cloud, token);
             });
             Ok(())
         } else {

--- a/src/api/spoc/auth.rs
+++ b/src/api/spoc/auth.rs
@@ -24,10 +24,7 @@ impl super::SpocApi {
         // 再次调用 next 获取 refreshToken, 但我们用不着, 使用我们自己的机制刷新登陆状态
 
         self.cred.update(|c| {
-            // 至少 7 天, 但即使更多对我们也用处不大了, 也许以后有时间我会测一测极限时间
-            c.spoc_token.set(token.to_string(), 604800);
-            // 刷新 SSO 时效
-            c.sso.refresh(5400);
+            c.set(Location::Spoc, token.to_string());
         });
         Ok(())
     }

--- a/src/api/srs/auth.rs
+++ b/src/api/srs/auth.rs
@@ -20,10 +20,7 @@ impl super::SrsApi {
         match cookie.get("byxk.buaa.edu.cn", "/xsxk", "token") {
             Some(t) => {
                 self.cred.update(|c| {
-                    // TODO: 我们先默认十分钟过期, 待测试
-                    c.srs_token.set(t.to_string(), 600);
-                    // 刷新 SSO 时效
-                    c.sso.refresh(5400);
+                    c.set(Location::Srs, t.to_string());
                 });
                 Ok(())
             }

--- a/src/api/sso/auth.rs
+++ b/src/api/sso/auth.rs
@@ -1,3 +1,4 @@
+use crate::api::Location;
 use crate::error::{AuthError, Error};
 use crate::utils;
 
@@ -42,8 +43,7 @@ impl super::SsoApi {
         let res = self.post(login_url).form(&form).send().await?;
         if res.status().as_u16() == 200 {
             self.cred.update(|c| {
-                // 经验证 1.5 小时过期
-                c.sso.refresh(5400);
+                c.refresh(Location::Sso);
             });
             Ok(())
         } else {

--- a/src/api/tes/auth.rs
+++ b/src/api/tes/auth.rs
@@ -17,8 +17,7 @@ impl super::TesApi {
             return Err(Error::auth_expired(Location::Sso));
         }
         self.cred.update(|c| {
-            // 刷新 SSO 时效
-            c.sso.refresh(5400);
+            c.refresh(Location::Sso);
         });
         Ok(())
     }

--- a/src/api/user/auth.rs
+++ b/src/api/user/auth.rs
@@ -1,3 +1,4 @@
+use crate::api::Location;
 use crate::utils;
 
 impl super::UserApi {
@@ -21,8 +22,7 @@ impl super::UserApi {
             .send()
             .await?;
         self.cred.update(|c| {
-            // 刷新 SSO 时效
-            c.sso.refresh(5400);
+            c.refresh(Location::Sso);
         });
         Ok(())
     }


### PR DESCRIPTION
- Remove `set` and `refresh` on `CredentialItem`
- Add  `set` and `refresh` on `CredentialStore` with `Location` for unified management