### PR TITLE
remove: `LoginPolicy`

### DIFF
--- a/src/api/app/auth.rs
+++ b/src/api/app/auth.rs
@@ -3,7 +3,7 @@ use crate::api::Location;
 impl super::AppApi {
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/api/boya/auth.rs
+++ b/src/api/boya/auth.rs
@@ -5,7 +5,7 @@ impl super::BoyaApi {
     /// # Boya Login
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/api/boya/universal.rs
+++ b/src/api/boya/universal.rs
@@ -48,7 +48,7 @@ impl super::BoyaApi {
     pub async fn universal_request(&self, url: &str, query: &str) -> crate::Result<String> {
         let cred = &self.cred.load().boya_token;
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && cred.is_expired() {
+        if cred.is_expired() {
             self.login().await?;
         }
         // 首先尝试获取 token, 如果没有就可以直接返回了

--- a/src/api/class/auth.rs
+++ b/src/api/class/auth.rs
@@ -12,7 +12,7 @@ impl super::ClassApi {
     /// # Smart Classroom Login
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/api/class/opt.rs
+++ b/src/api/class/opt.rs
@@ -12,7 +12,7 @@ impl super::ClassApi {
     ///     - Example: `202320242`` is 2024 spring term, `202420251` is 2024 autumn term
     pub async fn query_course(&self, id: &str) -> crate::Result<Vec<ClassCourse>> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().class_token.is_expired() {
+        if self.cred.load().class_token.is_expired() {
             self.login().await?;
         }
         let cred = self.cred.load();
@@ -37,7 +37,7 @@ impl super::ClassApi {
     /// - Input: Course ID, from [ClassCourse]
     pub async fn query_schedule(&self, id: &str) -> crate::Result<Vec<ClassSchedule>> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().class_token.is_expired() {
+        if self.cred.load().class_token.is_expired() {
             self.login().await?;
         }
         let cred = self.cred.load();
@@ -62,7 +62,7 @@ impl super::ClassApi {
     /// - Input: Schedule ID, from [ClassSchedule]
     pub async fn checkin(&self, id: &str) -> crate::Result<Response> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().class_token.is_expired() {
+        if self.cred.load().class_token.is_expired() {
             self.login().await?;
         }
         let cred = self.cred.load();

--- a/src/api/cloud/auth.rs
+++ b/src/api/cloud/auth.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 impl super::CloudApi {
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 
@@ -65,7 +65,7 @@ impl super::CloudApi {
     pub(crate) async fn token(&self) -> crate::Result<&String> {
         let cred = &self.cred.load().cloud_token;
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && cred.is_expired() {
+        if cred.is_expired() {
             self.login().await?;
         }
         cred.value()

--- a/src/api/cloud/universal.rs
+++ b/src/api/cloud/universal.rs
@@ -8,7 +8,7 @@ impl super::CloudApi {
         // 首先尝试获取 token, 如果没有就可以直接返回了
         let cred = &self.cred.load().cloud_token;
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && cred.is_expired() {
+        if cred.is_expired() {
             self.login().await?;
         }
         let token = match cred.value() {

--- a/src/api/spoc/auth.rs
+++ b/src/api/spoc/auth.rs
@@ -5,7 +5,7 @@ impl super::SpocApi {
     /// # Spoc Login
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/api/spoc/universal.rs
+++ b/src/api/spoc/universal.rs
@@ -14,7 +14,7 @@ struct SpocState {
 impl super::SpocApi {
     pub async fn universal_request(&self, url: &str, query: &str) -> crate::Result<String> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().spoc_token.is_expired() {
+        if self.cred.load().spoc_token.is_expired() {
             self.login().await?;
         }
         let cred = self.cred.load();

--- a/src/api/srs/auth.rs
+++ b/src/api/srs/auth.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 impl super::SrsApi {
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/api/tes/auth.rs
+++ b/src/api/tes/auth.rs
@@ -5,7 +5,7 @@ impl super::TesApi {
     /// Teacher Evaluation System Login
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/api/user/auth.rs
+++ b/src/api/user/auth.rs
@@ -5,7 +5,7 @@ impl super::UserApi {
     /// # User Center Login
     pub async fn login(&self) -> crate::Result<()> {
         // 因为我们可以知道 Token 是否过期, 我们这里只完成保守的刷新, 仅在 Token 超出我们预期时刷新 Token
-        if self.policy.load().is_auto() && self.cred.load().sso.is_expired() {
+        if self.cred.load().sso.is_expired() {
             self.api::<crate::api::Core>().login().await?;
         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::request::{Client, LoginPolicy, client};
+use crate::request::{Client, client};
 use crate::store::cookies::AtomicCookieStore;
 use crate::store::cred::CredentialStore;
 use crate::{api::Core, cell::AtomicCell};
@@ -13,7 +13,6 @@ pub struct Context<G = Core> {
     pub(crate) client: Client,
     pub(crate) cookies: Arc<AtomicCookieStore>,
     pub(crate) cred: AtomicCell<CredentialStore>,
-    pub(crate) policy: AtomicCell<LoginPolicy>,
     _marker: PhantomData<G>,
 }
 
@@ -42,7 +41,6 @@ impl Context {
             client,
             cookies,
             cred: AtomicCell::new(CredentialStore::default()),
-            policy: AtomicCell::new(LoginPolicy::Auto),
             _marker: PhantomData,
         }
     }
@@ -69,7 +67,6 @@ impl Context {
             client,
             cookies,
             cred: AtomicCell::new(cred),
-            policy: AtomicCell::new(LoginPolicy::Auto),
             _marker: PhantomData,
         }
     }
@@ -136,10 +133,6 @@ impl Context {
 
     pub fn set_cred(&self, cred: CredentialStore) {
         self.cred.store(cred);
-    }
-
-    pub fn set_policy(&self, policy: LoginPolicy) {
-        self.policy.store(policy);
     }
 
     pub fn get_cookies(&self) -> &AtomicCookieStore {

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,15 +18,3 @@ pub(crate) fn client<C: reqwest::cookie::CookieStore + 'static>(cookies: Arc<C>)
         .build()
         .unwrap()
 }
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum LoginPolicy {
-    Manual,
-    Auto,
-}
-
-impl LoginPolicy {
-    pub fn is_auto(&self) -> bool {
-        matches!(self, LoginPolicy::Auto)
-    }
-}


### PR DESCRIPTION
Considering that there are few scenarios where a full manual refresh is necessary, auto-refresh is now left on, but still exposes the interface for users to manually refresh in advance